### PR TITLE
chore: add conda-forge recipe

### DIFF
--- a/conda/README.md
+++ b/conda/README.md
@@ -1,0 +1,60 @@
+# conda-forge recipe
+
+This directory contains the conda recipe used to publish `wildberries-sdk` to
+[conda-forge](https://conda-forge.org/). It is **not** consumed by the build
+pipelines in this repo — once accepted, conda-forge maintains a separate
+"feedstock" repository (`conda-forge/wildberries-sdk-feedstock`) and a bot
+auto-updates that feedstock from PyPI on every new release.
+
+## Submitting the recipe (one-time)
+
+1. Fork [`conda-forge/staged-recipes`](https://github.com/conda-forge/staged-recipes).
+2. Copy `conda/recipe/meta.yaml` from this repo into
+   `recipes/wildberries-sdk/meta.yaml` in your fork.
+3. Open a PR titled `Add wildberries-sdk` against `conda-forge/staged-recipes:main`.
+4. Wait for CI: the PR runs `linter`, `recipe-lint`, and builds on Linux/macOS/Windows.
+5. After review (usually a few maintainer comments), the PR is merged and a
+   feedstock repository is created automatically. From then on, the
+   conda-forge "regro" bot opens PRs against that feedstock whenever a new
+   PyPI release is detected — you only have to merge them.
+
+## Updating this file when the package changes
+
+After every PyPI release we should refresh `version` and `sha256` here so the
+recipe in this repo stays a faithful template. Typical refresh:
+
+```bash
+VERSION=$(curl -sS https://pypi.org/pypi/wildberries-sdk/json \
+  | python3 -c 'import json,sys; print(json.load(sys.stdin)["info"]["version"])')
+SHA256=$(curl -sS "https://pypi.org/pypi/wildberries-sdk/json" \
+  | python3 -c "
+import json,sys
+d=json.load(sys.stdin); v=d['info']['version']
+for f in d['releases'][v]:
+    if f['packagetype']=='sdist':
+        print(f['digests']['sha256'])
+")
+echo "version=$VERSION sha256=$SHA256"
+# update those two lines at the top of conda/recipe/meta.yaml
+```
+
+For the live package on conda-forge this is automatic — the bot scrapes PyPI.
+The copy here is purely for visibility and bootstrapping.
+
+## After acceptance
+
+Add a badge to the main README:
+
+```markdown
+[![conda-forge](https://img.shields.io/conda/vn/conda-forge/wildberries-sdk.svg)](https://anaconda.org/conda-forge/wildberries-sdk)
+```
+
+And users will install with:
+
+```bash
+conda install -c conda-forge wildberries-sdk
+# or
+mamba install -c conda-forge wildberries-sdk
+# or
+pixi add wildberries-sdk
+```

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -1,0 +1,71 @@
+{% set name = "wildberries-sdk" %}
+{% set version = "0.1.79" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name|replace("-", "_") }}-{{ version }}.tar.gz
+  sha256: 6a6196f577c68fec95b6fc6d261550c045272ab1020125602b8b4833471ceb59
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python >=3.8
+    - pip
+    - setuptools >=68,<77
+    - wheel
+  run:
+    - python >=3.8
+    - pydantic >=2.0.0
+    - urllib3 >=2.6.3
+    - python-dateutil >=2.8.2
+    - typing-extensions >=4.0.0
+
+test:
+  imports:
+    - wildberries_sdk
+    - wildberries_sdk.general
+    - wildberries_sdk.products
+    - wildberries_sdk.orders_fbs
+    - wildberries_sdk.orders_dbw
+    - wildberries_sdk.orders_dbs
+    - wildberries_sdk.in_store_pickup
+    - wildberries_sdk.orders_fbw
+    - wildberries_sdk.promotion
+    - wildberries_sdk.communications
+    - wildberries_sdk.tariffs
+    - wildberries_sdk.analytics
+    - wildberries_sdk.reports
+    - wildberries_sdk.finances
+    - wildberries_sdk.wbd
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/eslazarev/wildberries-sdk
+  summary: Wildberries OpenAPI clients (generated) for Python
+  description: |
+    Wildberries SDK is an auto-generated Python client for the official
+    Wildberries marketplace OpenAPI specifications. It exposes typed
+    clients for products, orders (FBS/DBW/DBS/FBW/click-collect), finances,
+    analytics, promotion, communications, tariffs, reports and the
+    Wildberries Digital area. The package is regenerated daily from the
+    upstream specs via GitHub Actions, so the API surface stays in sync
+    with what Wildberries actually publishes.
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  doc_url: https://github.com/eslazarev/wildberries-sdk/blob/main/docs/python/README.md
+  dev_url: https://github.com/eslazarev/wildberries-sdk
+
+extra:
+  recipe-maintainers:
+    - eslazarev


### PR DESCRIPTION
## Summary
- Adds `conda/recipe/meta.yaml` ready to submit to [`conda-forge/staged-recipes`](https://github.com/conda-forge/staged-recipes) — a noarch Python recipe that pulls the sdist from PyPI; runtime deps mirror `pyproject.toml` (pydantic, urllib3, python-dateutil, typing-extensions).
- Adds `conda/README.md` with one-time submission steps, sdist sha256 refresh snippet, and a post-acceptance install/badge note.

After the staged-recipes PR is merged, conda-forge creates a feedstock and the regro bot will keep it in sync with PyPI automatically — no further manual work in this repo.

## Test plan
- [ ] Submit `conda/recipe/meta.yaml` as a PR to `conda-forge/staged-recipes` (`recipes/wildberries-sdk/meta.yaml`)
- [ ] Verify `linter` / `recipe-lint` pass and Linux/macOS/Windows builds succeed in the staged-recipes CI
- [ ] After merge, confirm the feedstock repo `conda-forge/wildberries-sdk-feedstock` is created
- [ ] Run `conda install -c conda-forge wildberries-sdk` in a fresh env and import all 15 sub-packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)