### PR TITLE
fix: sanitize digit-leading schema names in client generation (#139)

### DIFF
--- a/scripts/generate-clients.sh
+++ b/scripts/generate-clients.sh
@@ -22,6 +22,9 @@ cleanup_tmp_specs() {
   if [[ -d "${ROOT_DIR}/.tmp-python-specs" ]]; then
     rmdir "${ROOT_DIR}/.tmp-python-specs" 2>/dev/null || true
   fi
+  if [[ -d "${ROOT_DIR}/.tmp-sanitized-specs" ]]; then
+    rmdir "${ROOT_DIR}/.tmp-sanitized-specs" 2>/dev/null || true
+  fi
 }
 trap cleanup_tmp_specs EXIT
 
@@ -252,8 +255,8 @@ for path in root.rglob("*.go"):
         new_text = new_text.replace(old, new)
 
     new_text = re.sub(
-        r"(func \\(o \\*[^)]+\\) GetLastOrderShkId\\(\\) int64 \\{.*?)(var ret )int32",
-        r"\\1\\2int64",
+        r"(func \(o \*[^)]+\) GetLastOrderShkId\(\) int64 \{.*?)(var ret )int32",
+        r"\g<1>\g<2>int64",
         new_text,
         flags=re.S,
     )
@@ -924,6 +927,73 @@ Path(sys.argv[2]).write_text("\n".join(out_lines) + "\n", encoding="utf-8")
 PY
 }
 
+sanitize_digit_schema_names() {
+  local input="$1"
+  local output="$2"
+
+  python3 - "${input}" "${output}" <<'PY'
+import re
+import shutil
+import sys
+
+src, dst = sys.argv[1], sys.argv[2]
+with open(src, encoding="utf-8") as f:
+    text = f.read()
+
+# Collect schema names under components.schemas (keys at indent 4).
+all_names = set()
+digit_names = []
+in_components = False
+in_schemas = False
+for line in text.split("\n"):
+    stripped = line.strip()
+    if not stripped:
+        continue
+    indent = len(line) - len(line.lstrip())
+    if re.match(r"^components:\s*$", line):
+        in_components = True
+        in_schemas = False
+        continue
+    if in_components and indent == 0:
+        in_components = False
+        in_schemas = False
+    elif in_components and indent == 2:
+        in_schemas = bool(re.match(r"^\s*schemas:\s*$", line))
+    elif in_components and in_schemas and indent == 4:
+        m = re.match(r"^    ([^\s:]+):\s*$", line)
+        if m:
+            all_names.add(m.group(1))
+            if m.group(1)[0].isdigit():
+                digit_names.append(m.group(1))
+
+if not digit_names:
+    shutil.copyfile(src, dst)
+    sys.exit(0)
+
+for name in digit_names:
+    new_name = f"Model{name}"
+    if new_name in all_names:
+        print(f"Warning: cannot rename schema {name}: {new_name} already exists", file=sys.stderr)
+        continue
+    text = re.sub(
+        rf"^    {re.escape(name)}:\s*$",
+        f"    {new_name}:",
+        text,
+        count=1,
+        flags=re.M,
+    )
+    text = re.sub(
+        rf"(#/components/schemas/){re.escape(name)}(['\"\s])",
+        rf"\g<1>{new_name}\g<2>",
+        text,
+    )
+    print(f"Renamed digit-leading schema: {name} -> {new_name}", file=sys.stderr)
+
+with open(dst, "w", encoding="utf-8") as f:
+    f.write(text)
+PY
+}
+
 to_container_path() {
   local path="$1"
   if [[ "${path}" != "${ROOT_DIR}/"* ]]; then
@@ -987,6 +1057,22 @@ for spec in "${specs[@]}"; do
     fi
   fi
 done
+
+# Schema names starting with a digit (e.g. 409SupplyDeliverError) break the Go
+# and PHP generators: the top-level model gets a Model prefix, but inline
+# sub-schemas keep the digit-leading name and produce invalid identifiers.
+# Renaming to Model<name> in the spec matches what the generators already emit
+# for the top-level model, so no public API changes in any language.
+sanitized_dir="${ROOT_DIR}/.tmp-sanitized-specs"
+mkdir -p "${sanitized_dir}"
+sanitized_inputs=()
+for input in "${inputs[@]}"; do
+  sanitized="${sanitized_dir}/$(basename "${input}")"
+  sanitize_digit_schema_names "${input}" "${sanitized}"
+  TMP_SPECS+=("${sanitized}")
+  sanitized_inputs+=("${sanitized}")
+done
+inputs=("${sanitized_inputs[@]}")
 
 langs=()
 while IFS= read -r lang; do


### PR DESCRIPTION
# fix: sanitize digit-leading schema names in client generation (#139)

Fixes #139 — the Go `orders_fbs` client did not compile because generated identifiers started with a digit (`type 409SupplyDeliverErrorData`).

## Root cause

The WB spec defines schemas whose names start with a digit: `409SupplyDeliverError` (orders-fbs), `400Response` (promotion), `4xxResponse` (reports). OpenAPI Generator sanitizes the top-level model name (`409SupplyDeliverError` → `Model409SupplyDeliverError`), but names derived for **inline sub-schemas** (`data`, `orders[]`, `metaDetails[]`) skip that sanitization, producing invalid identifiers in the Go and PHP generators. Cross-references were also inconsistent: other files referenced `Model409SupplyDeliverErrorData`, while the type was declared as `409SupplyDeliverErrorData`.

## Changes in `scripts/generate-clients.sh`

1. New preprocessing step `sanitize_digit_schema_names`: before generation, schemas with digit-leading names are renamed to `Model<name>` (definition + all `$ref`s) in a temporary copy of each spec. `Model<name>` is exactly what the generators already emit for the top-level model, so Python / Rust / npm public APIs are unchanged — only Go and PHP gain valid identifiers.
2. Fixed a broken regex in `fix_go_large_ids` (double-escaped backslashes made it never match), which left `var ret int32` inside the `int64` getter `GetLastOrderShkId()` — the `communications` Go module did not compile either.

## Effect on regenerated clients

- **Go**: `orders_fbs` gets valid `Model409SupplyDeliverError*` models; `communications` gets the `int32` → `int64` fix. Type renames are not breaking — the previous names did not compile, so no consumer could reference them.
- **PHP**: `orders_fbs` gets valid `Model409SupplyDeliverErrorData*` classes (previously `class 409SupplyDeliverErrorData` — a parse error).
- **Python / npm**: byte-identical output (verified).
- **Rust**: same struct names, only module file renames (`_409_supply_deliver_error.rs` → `model409_supply_deliver_error.rs`).

⚠️ The generator does not delete stale files. After regeneration, the old `model_409*`/`model__409*` (Go), `409SupplyDeliverError*.php` (PHP), `_409*`, `model_400_response.rs`, `model_4xx_response.rs` (Rust), `model_400_response.go` (Go promotion), `model_4xx_response.go` (Go reports) must be removed once, otherwise Go fails with `Model400Response redeclared`.

## Verification

- Full regeneration (14 specs × 5 languages, Docker image `openapitools/openapi-generator-cli:latest`, `PACKAGE_VERSION=0.1.131`): diffs appear only in models tied to the three renamed schemas; all other clients are unchanged (Python is wiped and regenerated by the script and came out byte-identical).
- `go build ./...` passes for all 14 Go modules (before: `orders_fbs` and `communications` failed).
- Runtime smoke test: unmarshal of a real 409 payload through `Model409SupplyDeliverError` → `Data` → `Orders[0]` → `MetaDetails[0]`, marshal round-trip, `lastOrderShkId` above `int32` max.
- `cargo check` passes for the three affected Rust crates; `php -l` passes for all regenerated PHP files.