### PR TITLE
fix: download specs with headful Chrome to pass WB anti-bot v2

### DIFF
--- a/scripts/download-specs-from-config.sh
+++ b/scripts/download-specs-from-config.sh
@@ -66,24 +66,35 @@ try_curl() {
   done
 }
 
-# Fallback: drive a headless Chromium via `patchright` (a Playwright fork
-# with deeper CDP patches) that can complete the WBAAS JS challenge.
+# Fallback: drive a real headful Google Chrome via `patchright` (a Playwright
+# fork with deeper CDP patches) that can complete the WBAAS JS challenge.
+# WB's v2 anti-bot blocks headless browsers, so we run Chrome headful — under a
+# virtual display (xvfb) on headless CI hosts.
 run_patchright() {
   if ! command -v node >/dev/null 2>&1 || ! command -v npm >/dev/null 2>&1; then
     echo "Error: node and npm are required for the patchright fallback." >&2
     exit 1
   fi
+  export PLAYWRIGHT_BROWSERS_PATH="${PLAYWRIGHT_BROWSERS_PATH:-${SCRIPT_DIR}/.playwright-browsers}"
   (
     cd "${SCRIPT_DIR}"
     if [[ ! -d node_modules/patchright ]]; then
       echo "Installing patchright..."
       npm install --silent --no-audit --no-fund --no-save patchright@^1.59.4
     fi
-    export PLAYWRIGHT_BROWSERS_PATH="${PLAYWRIGHT_BROWSERS_PATH:-${SCRIPT_DIR}/.playwright-browsers}"
-    npx --no-install patchright install chromium >/dev/null
+    # Install real Google Chrome (channel used by the downloader). Falls back to
+    # a system Chrome if the managed install is unavailable.
+    npx --no-install patchright install chrome >/dev/null 2>&1 || \
+      echo "Warning: 'patchright install chrome' failed; relying on system Chrome." >&2
   )
-  PLAYWRIGHT_BROWSERS_PATH="${PLAYWRIGHT_BROWSERS_PATH:-${SCRIPT_DIR}/.playwright-browsers}" \
-    node "${SCRIPT_DIR}/download-specs.mjs"
+
+  # Headful Chrome needs a display. Use xvfb-run when there's no DISPLAY (CI).
+  local runner=(node "${SCRIPT_DIR}/download-specs.mjs")
+  if [[ -z "${DISPLAY:-}" ]] && command -v xvfb-run >/dev/null 2>&1; then
+    xvfb-run -a "${runner[@]}"
+  else
+    "${runner[@]}"
+  fi
 }
 
 if try_curl; then

--- a/scripts/download-specs.mjs
+++ b/scripts/download-specs.mjs
@@ -31,7 +31,13 @@ if (urls.length === 0) {
 
 mkdirSync(specsDir, { recursive: true });
 
-const browser = await chromium.launch({ headless: true });
+// WB's WBAAS v2 anti-bot (rolled out Aug 2026) blocks headless browsers with a
+// "suspicious activity" challenge that never resolves. Running headful with the
+// real Google Chrome channel passes it. CI has no display, so the caller wraps
+// this in xvfb-run; locally the OS display is used. Override via env if needed.
+const channel = process.env.WB_BROWSER_CHANNEL || 'chrome';
+const headless = process.env.WB_HEADLESS === '1';
+const browser = await chromium.launch({ headless, channel });
 const context = await browser.newContext({
   userAgent:
     'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',


### PR DESCRIPTION
WB's WBAAS v2 anti-bot (rolled out Aug 2026) blocks headless browsers with a challenge that never resolves, breaking the scheduled spec sync. The patchright fallback now launches real Google Chrome headful (channel=chrome) under xvfb on displayless CI hosts. Verified locally: curl 498 -> headful Chrome passes the challenge -> all 13 specs download.